### PR TITLE
Remove default settings

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -12,8 +12,8 @@ Redmine::Plugin.register :redmine_issue_open_date do
   author 'Centos-admin.ru'
   author_url 'http://centos-admin.ru'
   settings(default: {
-    'freezed_statuses' => IssueStatus.where(is_closed: true).pluck(:id).map(&:to_s),
-    'open_status' => IssueStatus.sorted.first.id.to_s
+    'freezed_statuses' => [],
+    'open_status' => []
                     },
            partial: 'settings/issue_open_date')
 


### PR DESCRIPTION
Remove default settings because it breaks redmine installation.

```
constXife @ constXife ~ % bin/rake db:migrate                                                                                                                                                         15:25
rake aborted!
ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "issue_statuses" does not exist
LINE 5:                WHERE a.attrelid = '"issue_statuses"'::regcla...
                                          ^
:               SELECT a.attname, format_type(a.atttypid, a.atttypmod),
                     pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod
                FROM pg_attribute a LEFT JOIN pg_attrdef d
                  ON a.attrelid = d.adrelid AND a.attnum = d.adnum
               WHERE a.attrelid = '"issue_statuses"'::regclass
                 AND a.attnum > 0 AND NOT a.attisdropped
               ORDER BY a.attnum
```